### PR TITLE
Fixes error swallowing when using .nvmrc

### DIFF
--- a/functions/__nvm_run.fish
+++ b/functions/__nvm_run.fish
@@ -9,11 +9,6 @@ function __nvm_run
   function run_command
     set stack (status stack-trace | grep called | cut -d " " -f 7)
     set count (count $argv)
-    if test "$count" -ge 2
-      set args $argv[2..-1]
-    else
-      set args ""
-    end
 
     if type -fqP $argv[1]; and test "$stack[1]" != (which $argv[1])
       set count (count $argv)
@@ -48,12 +43,15 @@ function __nvm_run
   end
 
   if not test -n "$NVM_HAS_RUN"
-    if test -f .nvmrc; and nvm use > /dev/null 2>&1
-      if can_run_command $argv[1]
+    if test -f .nvmrc;
+      set nvm_output (nvm use)
+      set nvm_status $status
+      if test $nvm_status -gt 0
+        echo $nvm_output
+      end
+      if test $nvm_status -eq 0; and can_run_command $argv[1]
         set -gx NVM_HAS_RUN 1
         run_command $argv
-      else
-        run_default $argv
       end
     else
       run_default $argv


### PR DESCRIPTION
When a .nvmrc exists in the folder with a version that it's not
installed. fish-nvm swallows the error and says that command
(node,npm,npx,etc) is not installed.

closes #36 