### PR TITLE
Fix: osx PATH on sub shells

### DIFF
--- a/functions/__nvm_run.fish
+++ b/functions/__nvm_run.fish
@@ -6,6 +6,14 @@ function __nvm_run
     return 1
   end
 
+  if test (uname -s) = 'Darwin'; and string match -q "*versions/node/*/bin" $PATH
+    set -l nvm_node_path (string match "*versions/node/*/bin" $PATH)
+    set -l nvm_index (contains -i -- $nvm_node_path $PATH)
+    if test $nvm_index -gt 1
+      set -gx PATH $nvm_node_path (string match -v $nvm_node_path $PATH)
+    end
+  end
+
   function run_command
     set stack (status stack-trace | grep called | cut -d " " -f 7)
     set count (count $argv)


### PR DESCRIPTION
When using fish-nvm on OSX with subshells the PATH get's re ordered. 
This is something than happens with OSX only, more info regarding that https://github.com/fish-shell/fish-shell/pull/5956

This PR checks if there's a nvm path in `$PATH` if there is and i's not the first element remove it and pre append to the list again.