### PR TITLE
fixes minor bug on nvm_alias_command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,36 @@ nvm wrapper for fish-shell.
 
 Make sure you have [NVM] installed first.
 
-With [fisher](https://github.com/jorgebucaran/fisher)
+### With [fisher]
 
 ```fish
 fisher add FabioAntunes/fish-nvm
 fisher add edc/bass
 ```
 
-With [oh-my-fish]
+### With [oh-my-fish]
+
 ```fish
-omf install https://github.com/FabioAntunes/fish-nvm
+omf install https://github.com/fabioantunes/fish-nvm
 omf install https://github.com/edc/bass
 ```
+
+### With [fundle]
+
+```fish
+fundle plugin 'FabioAntunes/fish-nvm'
+fundle plugin 'edc/bass'
+fundle install
+```
+
+Add these lines to `~/.config/fish/config.fish`
+
+```fish
+fundle plugin 'FabioAntunes/fish-nvm'
+fundle plugin 'edc/bass'
+fundle init
+```
+
 
 **fish-nvm** depends on [bass] 
 
@@ -149,7 +167,9 @@ Adding it will cause error: `nvm is not compatible with the npm config "prefix" 
 
 [NVM]: https://github.com/creationix/nvm
 [brew]: https://brew.sh/
+[fisher]: https://github.com/jorgebucaran/fisher
 [oh-my-fish]: https://github.com/oh-my-fish/oh-my-fish
+[fundle]: https://github.com/danhper/fundle
 [bass]: https://github.com/edc/bass
 
 ### License

--- a/functions/nvm_alias_command.fish
+++ b/functions/nvm_alias_command.fish
@@ -21,7 +21,7 @@ function nvm_alias_command -d "Create an alias command"
         return (chmod +x $argv[1])
       else
         printf "\U274C failed creating  %s alias command at %s\n" $argv[2] $argv[1]
-        printf "Probably a permissions problem, try running sudo fish and then nvm_alias_command\n"
+        printf "Probably a permissions problem, try running sudo fish, and then nvm_alias_command\n"
       end
     end
   end
@@ -31,23 +31,15 @@ function nvm_alias_command -d "Create an alias command"
 
   if test $status -ge 1
     printf "\U274C failed creating dir $outputPath."
-    printf "Probably a permissions problem, try running sudo fish and then nvm_alias_command\n"
+    printf "Probably a permissions problem, try running sudo fish, and then nvm_alias_command\n"
     exit 1
   end
 
   if test (count $argv) -le 0
-    set -l path ( dirname (readlink -f (status --current-filename)))
-    set -l aliases (command ls -1 (realpath $path))
+    set -l aliases node npm npx yarn
 
-    for val in $aliases
-      if test $val != "nvm.fish";
-        and test $val != "nvm_alias_command.fish";
-        and test $val != "nvm_alias_function.fish";
-        and test $val != "__nvm_run.fish"
-
-        set -l alias (string replace .fish '' $val)
+    for alias in $aliases
         __create_alias_command "$outputPath/$alias" $alias
-      end
     end
   else
     for arg in $argv


### PR DESCRIPTION
* Fixes minor bug on `nvm_alias_command`, removes all the symlink stuff and just uses a hardcoded list
* Adds fundle instructions to the readme

closes #46 