### PR TITLE
Use consistent capitalization, use one-liner installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Adding it will cause error: `nvm is not compatible with the npm config "prefix" 
 
 [NVM]: https://github.com/creationix/nvm
 [brew]: https://brew.sh/
-[fisher]: https://github.com/jorgebucaran/fisher
+[Fisher]: https://github.com/jorgebucaran/fisher
 [oh-my-fish]: https://github.com/oh-my-fish/oh-my-fish
 [fundle]: https://github.com/danhper/fundle
 [bass]: https://github.com/edc/bass

--- a/README.md
+++ b/README.md
@@ -6,11 +6,10 @@
 
 Make sure you have [NVM] installed first.
 
-### With [fisher]
+### With [Fisher]
 
 ```fish
-fisher install FabioAntunes/fish-nvm
-fisher install edc/bass
+fisher install FabioAntunes/fish-nvm edc/bass
 ```
 
 ### With [oh-my-fish]


### PR DESCRIPTION
Here's another PR! 😅 

- I'd strongly prefer if plugins use the same capitalization we use upstream for Fisher, not ~~fisher~~. 
  - I'd much prefer Fish over fish or fish-shell, but I didn't touch any of that here as you might reasonably consider that opinionated and there's nothing wrong with your current choice either.
- Because Fisher installs plugins concurrently, a one-liner is more idiomatic, and faster. ✌️ 