### PR TITLE
Fix version number regex in completions

### DIFF
--- a/completions/nvm.fish
+++ b/completions/nvm.fish
@@ -3,7 +3,7 @@
 
 function __nvm_complete_ls_remote
   if not test "$__nvm_ls_remote"
-    set -g __nvm_ls_remote (nvm ls-remote | grep -Po '(?:iojs-)?v[0-9]\.[0-9]\.[0-9]*')
+    set -g __nvm_ls_remote (nvm ls-remote | grep -Po '(?:iojs-)?v[0-9]+\.[0-9]+\.[0-9]+')
   end
 
   printf "%s\n" $__nvm_ls_remote
@@ -11,7 +11,7 @@ end
 
 function __nvm_complete_ls
   if not test "$__nvm_ls"
-    set -g __nvm_ls (nvm ls | grep -Po '[[:space:]].\K(v[0-9]\.[0-9]\.[0-9]*)')
+    set -g __nvm_ls (nvm ls | grep -Po '[[:space:]].\K(v[0-9]+\.[0-9]+\.[0-9]+)')
   end
 
   printf "%s\n" $__nvm_ls


### PR DESCRIPTION
The current regex used in the completions only matches version numbers containing single digits (e.g. v1.2.3). This fixes it so that it will also include version numbers with multiple digits (e.g. 16.0.1).