### PR TITLE
Use `type` instead of `which`

### DIFF
--- a/functions/__nvm_run.fish
+++ b/functions/__nvm_run.fish
@@ -18,7 +18,7 @@ function __nvm_run
     set stack (status stack-trace | grep called | cut -d " " -f 7)
     set count (count $argv)
 
-    if type -fq $argv[1]; and test "$stack[1]" != (which $argv[1])
+    if type -fq $argv[1]; and test "$stack[1]" != (type -fP $argv[1])
       set count (count $argv)
       if test "$count" -ge 2
         set args $argv[2..-1]


### PR DESCRIPTION
I use a `which` function to give more verbose output for commands that are symlinks, which breaks `run_command`.

Another fix would be to use `command which`, but using `type` also seems more consistent with the `eval` commands directly afterwards.